### PR TITLE
RHTAPBUGS-939: fix 'Need to confirm recovery settings'

### DIFF
--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -54,8 +54,7 @@ describe('template spec',
       });
 
       cy.get('body').then(($el) => {
-        cy.task('log', $el.find('input[type="submit"]'))
-        if ($el.find('input[type="submit"][name="type"][value="confirmed"]').length > 0) {
+        if ($el.find('button[type="submit"]').length > 0) {
           cy.task('log', 'Need to confirm recovery settings')
           cy.get('button[type="submit"]').click();
         } else {

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -54,9 +54,9 @@ describe('template spec',
       });
 
       cy.get('body').then(($el) => {
-        if ($el.find('input[type="submit"][name="type"][value="confirmed"]').length > 0) {
+        if ($el.find('button[type="submit"]').length > 0) {
           cy.task('log', 'Need to confirm recovery settings')
-          cy.get('input[type="submit"][name="type"][value="confirmed"]').click();
+          cy.get('button[type="submit"]').click();
         } else {
           cy.task('log', 'No need to confirm recovery settings')
         }


### PR DESCRIPTION
# Description

- fix 'Need to confirm recovery settings' since it is not working as expected. 

It is skipping this part since the "old" verification was trying to find an input that does not exist. We should look for button.
![image](https://github.com/redhat-appstudio-qe/cypress-browser-oauth-flow/assets/119665479/c3287cd5-e2cf-4a8e-829d-d0a792ca3e68)


## Issue ticket number and link
[RHTAPBUGS-939](https://issues.redhat.com/browse/RHTAPBUGS-939)