### PR TITLE
fix 'Need to confirm recovery settings'

### DIFF
--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -1,77 +1,75 @@
-describe('template spec', 
+describe('template spec',
   {
     "retries": 3
   },
   () => {
-  it('check variables', () => {   
-    console.log(Cypress.env('SPI_OAUTH_URL'))
-    expect(Cypress.env('GH_USER')).to.not.be.empty
-    expect(Cypress.env('GH_PASSWORD')).to.not.be.empty
-    expect(Cypress.env('GH_2FA_CODE')).to.not.be.empty
-    expect(Cypress.env('SPI_OAUTH_URL')).to.not.be.empty
-  })
-
-  it('passes', () => {   
-
-    const attempt = Cypress.currentRetry
-    cy.task('log', 'Waiting ' + attempt*5*1000 + ' milliseconds - attempt #' + attempt)
-    cy.wait(attempt*10*1000)
-    
-    cy.task('log', 'Visiting '+Cypress.env('SPI_OAUTH_URL'))
-    cy.visit(Cypress.env('SPI_OAUTH_URL'))
-    
-    cy.url().then((url) => {
-      cy.task('log', 'Current URL is: ' + url)
+    it('check variables', () => {
+      console.log(Cypress.env('SPI_OAUTH_URL'))
+      expect(Cypress.env('GH_USER')).to.not.be.empty
+      expect(Cypress.env('GH_PASSWORD')).to.not.be.empty
+      expect(Cypress.env('GH_2FA_CODE')).to.not.be.empty
+      expect(Cypress.env('SPI_OAUTH_URL')).to.not.be.empty
     })
-    
-    cy.origin('https://github.com/login', () => {
-      
-      cy.get('#login_field').should('exist')
-      cy.get('#password').should('exist')
-      cy.get('input[type="submit"][name="commit"]').should('exist')
 
+    it('passes', () => {
+
+      const attempt = Cypress.currentRetry
+      cy.task('log', 'Waiting ' + attempt * 5 * 1000 + ' milliseconds - attempt #' + attempt)
+      cy.wait(attempt * 10 * 1000)
+
+      cy.task('log', 'Visiting ' + Cypress.env('SPI_OAUTH_URL'))
+      cy.visit(Cypress.env('SPI_OAUTH_URL'))
+
+      cy.url().then((url) => {
+        cy.task('log', 'Current URL is: ' + url)
+      })
+
+      cy.origin('https://github.com/login', () => {
+
+        cy.get('#login_field').should('exist')
+        cy.get('#password').should('exist')
+        cy.get('input[type="submit"][name="commit"]').should('exist')
+
+        cy.url().then((url) => {
+          cy.task('log', 'Current Github URL is: ' + url)
+        })
+
+        cy.get('#login_field').type(Cypress.env('GH_USER'), { log: false });
+        cy.get('#password').type(Cypress.env('GH_PASSWORD'), { log: false });
+        cy.get('input[type="submit"][name="commit"]').click();
+
+        cy.task("generateToken", Cypress.env('GH_2FA_CODE')).then(token => {
+          cy.get("#app_totp").type(token, { log: false });
+          cy.task('log', 'Generated token')
+          expect(token).to.not.be.empty
+        });
+
+        cy.get('body').then(($el) => {
+          if ($el.find('#js-oauth-authorize-btn').length > 0) {
+            cy.task('log', 'Need to authorize app')
+            cy.get('#js-oauth-authorize-btn').click();
+          } else {
+            cy.task('log', 'No need to authorize app')
+          }
+        });
+
+        cy.get('body').then(($el) => {
+          if ($el.find('button[type="submit"]').length > 0) {
+            cy.task('log', 'Need to confirm recovery settings')
+            cy.get('button[type="submit"]').last().click();
+          } else {
+            cy.task('log', 'No need to confirm recovery settings')
+          }
+        });
+
+      })
+
+      cy.location('pathname')
+        .should('include', '/callback_success')
       cy.url().then((url) => {
         cy.task('log', 'Current Github URL is: ' + url)
       })
 
-      cy.get('#login_field').type(Cypress.env('GH_USER'), { log: false });
-      cy.get('#password').type(Cypress.env('GH_PASSWORD'), { log: false });
-      cy.get('input[type="submit"][name="commit"]').click();
-      
-      cy.task("generateToken", Cypress.env('GH_2FA_CODE')).then(token => {
-        cy.get("#app_totp").type(token, { log: false });
-        cy.task('log', 'Generated token')
-        expect(token).to.not.be.empty
-      });
-      
-      cy.get('body').then(($el) => {
-        if ($el.find('#js-oauth-authorize-btn').length > 0) {
-          cy.task('log', 'Need to authorize app')
-          cy.get('#js-oauth-authorize-btn').click();
-        } else {
-          cy.task('log', 'No need to authorize app')
-        }
-      });
-
-      cy.get('body').then(($el) => {
-        cy.task('log', $el.find('input[type="submit"]'))
-        if ($el.find('input[type="submit"][name="type"][value="confirmed"]').length > 0) {
-          cy.task('log', 'Need to confirm recovery settings')
-          cy.get('input[type="submit"][name="type"][value="confirmed"]').click();
-        } else {
-          cy.task('log', 'No need to confirm recovery settings')
-        }
-      });
-
-    })
-
-    cy.location('pathname')
-      .should('include', '/callback_success')
-    cy.url().then((url) => {
-      cy.task('log', 'Current Github URL is: ' + url)  
     })
 
   })
-
-})
-


### PR DESCRIPTION
# Description

- fix 'Need to confirm recovery settings' since it is not working as expected. 

It is skipping this part since the "old" verification was trying to find an input that does not exist. We should look for the last button (in this case, the "Remind me later").
![image](https://github.com/redhat-appstudio-qe/cypress-browser-oauth-flow/assets/119665479/c3287cd5-e2cf-4a8e-829d-d0a792ca3e68)


## Issue ticket number and link
[RHTAPBUGS-939](https://issues.redhat.com/browse/RHTAPBUGS-939)